### PR TITLE
Add unsafe feature within flatbuffer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Benchmark for serialization in Rust, https://github.com/apache/incubator-horaedb
 
 # Usage
 ```sh
-%> serialization-benchmark-rs --help
+[]# serialization-benchmark-rs --help
 Usage: serialization-benchmark-rs [OPTIONS]
 
 Options:
@@ -16,13 +16,24 @@ Options:
   -V, --version                  Print version
 
 
-%> cargo run
+[]# ./serialization-benchmark-rs 
 Benchmark test, batch_size=1000000, result: 
 
 +------------+----------------+------------------+-------------+
 | name       | serialize time | deserialize time | cpu_utility |
-| flatbuffer | 0.32837144(s)  | 1.5406052(s)     | 11.836201   |
-| fury       | 2.7501004(s)   | 2.738932(s)      | 20.819456   |
-| protobuf   | 1.4705708(s)   | 2.3939092(s)     | 20.486391   |
+| flatbuffer | 0.043271985(s) | 0.2820203(s)     | 30.636393   |
+| fury       | 0.4075856(s)   | 0.3214576(s)     | 28.214052   |
+| protobuf   | 0.2138659(s)   | 0.3004469(s)     | 25.609756   |
++------------+----------------+------------------+-------------+
+
+[]# ./serialization-benchmark-rs --batch-size 5000000
+Benchmark test, batch_size=5000000, result: 
+
++------------+----------------+------------------+-------------+
+| name       | serialize time | deserialize time | cpu_utility |
+| flatbuffer | 0.21562137(s)  | 1.4061759(s)     | 29.822226   |
+| fury       | 2.0300736(s)   | 1.6155167(s)     | 25.778494   |
+| protobuf   | 1.065279(s)    | 1.5093864(s)     | 25.547447   |
 +------------+----------------+------------------+-------------+
 ```
+

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Benchmark test, batch_size=5000000, result:
 | protobuf   | 1.065279(s)    | 1.5093864(s)     | 25.547447   |
 +------------+----------------+------------------+-------------+
 
-[]# ./serialization-benchmark-rs --unsafe
+[]# ./serialization-benchmark-rs --enable-unsafe
 Benchmark test, batch_size=1000000, result: 
 
 +------------+----------------+------------------+-------------+

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Usage: serialization-benchmark-rs [OPTIONS]
 
 Options:
       --batch-size <BATCH_SIZE>  [env: BATCH_SIZE=] [default: 1000000]
+      --unsafe                   use unsafe feature within flatbuffer [env: UNSAFE=]
   -h, --help                     Print help
   -V, --version                  Print version
 
@@ -21,9 +22,9 @@ Benchmark test, batch_size=1000000, result:
 
 +------------+----------------+------------------+-------------+
 | name       | serialize time | deserialize time | cpu_utility |
-| flatbuffer | 0.043271985(s) | 0.2820203(s)     | 30.636393   |
-| fury       | 0.4075856(s)   | 0.3214576(s)     | 28.214052   |
-| protobuf   | 0.2138659(s)   | 0.3004469(s)     | 25.609756   |
+| flatbuffer | 0.049742587(s) | 0.2990468(s)     | 27.905426   |
+| fury       | 0.4078921(s)   | 0.31441632(s)    | 26.46583    |
+| protobuf   | 0.22009465(s)  | 0.3065254(s)     | 28.004875   |
 +------------+----------------+------------------+-------------+
 
 []# ./serialization-benchmark-rs --batch-size 5000000
@@ -34,6 +35,16 @@ Benchmark test, batch_size=5000000, result:
 | flatbuffer | 0.21562137(s)  | 1.4061759(s)     | 29.822226   |
 | fury       | 2.0300736(s)   | 1.6155167(s)     | 25.778494   |
 | protobuf   | 1.065279(s)    | 1.5093864(s)     | 25.547447   |
++------------+----------------+------------------+-------------+
+
+[]# ./serialization-benchmark-rs --unsafe
+Benchmark test, batch_size=1000000, result: 
+
++------------+----------------+------------------+-------------+
+| name       | serialize time | deserialize time | cpu_utility |
+| flatbuffer | 0.055235952(s) | 0.02805682(s)    | 29.246042   |
+| fury       | 0.4071525(s)   | 0.31315032(s)    | 26.696833   |
+| protobuf   | 0.216035(s)    | 0.30267346(s)    | 25.301205   |
 +------------+----------------+------------------+-------------+
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,9 @@ mod util;
 use clap::Parser;
 use std::time::Duration;
 use util::Serializable;
-use util::{EnDecodeDuration, FlatBuffersObject, FuryObject, ProtobufObject, RawPerson, RawPet};
+use util::{
+    EnDecodeDuration, FlatBuffersObject, FuryObject, ProtobufObject, RawPerson, RawPet, TestContext,
+};
 #[macro_use]
 extern crate prettytable;
 use prettytable::{Cell, Row, Table};
@@ -16,7 +18,7 @@ struct Args {
     batch_size: usize,
 
     #[arg(long, env, help = "use unsafe feature within flatbuffer")]
-    r#unsafe: bool,
+    enable_unsafe: bool,
 }
 
 fn main() {
@@ -33,7 +35,7 @@ fn main() {
 
     println!("Benchmark test, batch_size={}, result: \n", args.batch_size);
     let n: usize = args.batch_size;
-    let r#unsafe = args.r#unsafe;
+    let enable_unsafe = args.enable_unsafe;
     let raw_person = RawPerson {
         name: "Mr' White".to_string(),
         age: 18,
@@ -54,16 +56,19 @@ fn main() {
         let mut flatbuffer_objects = Vec::new();
         (0..n).for_each(|_| flatbuffer_objects.push(FlatBuffersObject::new(&raw_person)));
 
-        let mut duration_trace: EnDecodeDuration = (Duration::new(0, 0), Duration::new(0, 0));
+        let mut context = TestContext {
+            duration: (Duration::new(0, 0), Duration::new(0, 0)),
+            enable_unsafe: args.enable_unsafe,
+        };
         flatbuffer_objects
             .iter_mut()
-            .for_each(|x| x.serialize_and_deserialize(&mut duration_trace, r#unsafe));
+            .for_each(|x| x.serialize_and_deserialize(&mut context));
 
         cpu_trace.refresh_cpu();
         table.add_row(Row::new(vec![
             Cell::new("flatbuffer"),
-            Cell::new(format!("{:?}(s)", duration_trace.0.as_secs_f32()).as_str()),
-            Cell::new(format!("{:?}(s)", duration_trace.1.as_secs_f32()).as_str()),
+            Cell::new(format!("{:?}(s)", context.duration.0.as_secs_f32()).as_str()),
+            Cell::new(format!("{:?}(s)", context.duration.1.as_secs_f32()).as_str()),
             Cell::new(
                 format!(
                     "{:?}",
@@ -81,15 +86,18 @@ fn main() {
             System::new_with_specifics(RefreshKind::new().with_cpu(CpuRefreshKind::everything()));
         let mut fury_objects = Vec::new();
         (0..n).for_each(|_| fury_objects.push(FuryObject::new(&raw_person)));
-        let mut duration_trace: EnDecodeDuration = (Duration::new(0, 0), Duration::new(0, 0));
+        let mut context = TestContext {
+            duration: (Duration::new(0, 0), Duration::new(0, 0)),
+            enable_unsafe: args.enable_unsafe,
+        };
         fury_objects
             .iter_mut()
-            .for_each(|x| x.serialize_and_deserialize(&mut duration_trace, r#unsafe));
+            .for_each(|x| x.serialize_and_deserialize(&mut context));
         cpu_trace.refresh_cpu();
         table.add_row(Row::new(vec![
             Cell::new("fury"),
-            Cell::new(format!("{:?}(s)", duration_trace.0.as_secs_f32()).as_str()),
-            Cell::new(format!("{:?}(s)", duration_trace.1.as_secs_f32()).as_str()),
+            Cell::new(format!("{:?}(s)", context.duration.0.as_secs_f32()).as_str()),
+            Cell::new(format!("{:?}(s)", context.duration.1.as_secs_f32()).as_str()),
             Cell::new(
                 format!(
                     "{:?}",
@@ -107,15 +115,18 @@ fn main() {
             System::new_with_specifics(RefreshKind::new().with_cpu(CpuRefreshKind::everything()));
         let mut protobuf_objects = Vec::new();
         (0..n).for_each(|_| protobuf_objects.push(ProtobufObject::new(&raw_person)));
-        let mut duration_trace: EnDecodeDuration = (Duration::new(0, 0), Duration::new(0, 0));
+        let mut context = TestContext {
+            duration: (Duration::new(0, 0), Duration::new(0, 0)),
+            enable_unsafe: args.enable_unsafe,
+        };
         protobuf_objects
             .iter_mut()
-            .for_each(|x| x.serialize_and_deserialize(&mut duration_trace, r#unsafe));
+            .for_each(|x| x.serialize_and_deserialize(&mut context));
         cpu_trace.refresh_cpu();
         table.add_row(Row::new(vec![
             Cell::new("protobuf"),
-            Cell::new(format!("{:?}(s)", duration_trace.0.as_secs_f32()).as_str()),
-            Cell::new(format!("{:?}(s)", duration_trace.1.as_secs_f32()).as_str()),
+            Cell::new(format!("{:?}(s)", context.duration.0.as_secs_f32()).as_str()),
+            Cell::new(format!("{:?}(s)", context.duration.1.as_secs_f32()).as_str()),
             Cell::new(
                 format!(
                     "{:?}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,9 @@ use sysinfo::{CpuRefreshKind, RefreshKind, System};
 struct Args {
     #[clap(default_value = "1000000", long, env)]
     batch_size: usize,
+
+    #[arg(long, env, help = "use unsafe feature within flatbuffer")]
+    r#unsafe: bool,
 }
 
 fn main() {
@@ -30,6 +33,7 @@ fn main() {
 
     println!("Benchmark test, batch_size={}, result: \n", args.batch_size);
     let n: usize = args.batch_size;
+    let r#unsafe = args.r#unsafe;
     let raw_person = RawPerson {
         name: "Mr' White".to_string(),
         age: 18,
@@ -53,7 +57,7 @@ fn main() {
         let mut duration_trace: EnDecodeDuration = (Duration::new(0, 0), Duration::new(0, 0));
         flatbuffer_objects
             .iter_mut()
-            .for_each(|x| x.serialize_and_deserialize(&mut duration_trace));
+            .for_each(|x| x.serialize_and_deserialize(&mut duration_trace, r#unsafe));
 
         cpu_trace.refresh_cpu();
         table.add_row(Row::new(vec![
@@ -80,7 +84,7 @@ fn main() {
         let mut duration_trace: EnDecodeDuration = (Duration::new(0, 0), Duration::new(0, 0));
         fury_objects
             .iter_mut()
-            .for_each(|x| x.serialize_and_deserialize(&mut duration_trace));
+            .for_each(|x| x.serialize_and_deserialize(&mut duration_trace, r#unsafe));
         cpu_trace.refresh_cpu();
         table.add_row(Row::new(vec![
             Cell::new("fury"),
@@ -106,7 +110,7 @@ fn main() {
         let mut duration_trace: EnDecodeDuration = (Duration::new(0, 0), Duration::new(0, 0));
         protobuf_objects
             .iter_mut()
-            .for_each(|x| x.serialize_and_deserialize(&mut duration_trace));
+            .for_each(|x| x.serialize_and_deserialize(&mut duration_trace, r#unsafe));
         cpu_trace.refresh_cpu();
         table.add_row(Row::new(vec![
             Cell::new("protobuf"),
@@ -125,3 +129,4 @@ fn main() {
 
     table.printstd();
 }
+


### PR DESCRIPTION
# Rationale
Add unsafe feature within flatbuffer.

# Detailed Changes
Add unsafe feature within flatbuffer.

# Test Plan
Manual test.

```sh
[]# ./serialization-benchmark-rs 
Benchmark test, batch_size=1000000, result: 

+------------+----------------+------------------+-------------+
| name       | serialize time | deserialize time | cpu_utility |
| flatbuffer | 0.049742587(s) | 0.2990468(s)     | 27.905426   |
| fury       | 0.4078921(s)   | 0.31441632(s)    | 26.46583    |
| protobuf   | 0.22009465(s)  | 0.3065254(s)     | 28.004875   |
+------------+----------------+------------------+-------------+

[]# ./serialization-benchmark-rs --batch-size 5000000
Benchmark test, batch_size=5000000, result: 

+------------+----------------+------------------+-------------+
| name       | serialize time | deserialize time | cpu_utility |
| flatbuffer | 0.21562137(s)  | 1.4061759(s)     | 29.822226   |
| fury       | 2.0300736(s)   | 1.6155167(s)     | 25.778494   |
| protobuf   | 1.065279(s)    | 1.5093864(s)     | 25.547447   |
+------------+----------------+------------------+-------------+

[]# ./serialization-benchmark-rs --unsafe
Benchmark test, batch_size=1000000, result: 

+------------+----------------+------------------+-------------+
| name       | serialize time | deserialize time | cpu_utility |
| flatbuffer | 0.055235952(s) | 0.02805682(s)    | 29.246042   |
| fury       | 0.4071525(s)   | 0.31315032(s)    | 26.696833   |
| protobuf   | 0.216035(s)    | 0.30267346(s)    | 25.301205   |
+------------+----------------+------------------+-------------+
```